### PR TITLE
add simulation rate variable

### DIFF
--- a/FlightStreamDeck.Core/Structs.cs
+++ b/FlightStreamDeck.Core/Structs.cs
@@ -566,6 +566,7 @@
         TRANSPONDER_STATE__1,
         NAV_SOUND__1,
         NAV_SOUND__2,
+        SIMULATION_RATE,
     }
 
     public enum TOGGLE_EVENT


### PR DESCRIPTION
This PR adds the SIMULATION_RATE variable so we can display the sim rate (how fast/slow time is running in the simulator) on the device.