### PR TITLE
#26 - User defined value precision & unit into ValueEntry.

### DIFF
--- a/FlightStreamDeck.AddOn/PropertyInspector/GenericGauge.html
+++ b/FlightStreamDeck.AddOn/PropertyInspector/GenericGauge.html
@@ -38,6 +38,10 @@
             <input class="sdpi-item-value" id="MaxValue" value="" placeholder="100" onchange="updateData()" pattern="[0-9.-]">
         </div>
         <div class="sdpi-item" type="field">
+            <div class="sdpi-item-label">Value Units</div>
+            <input class="sdpi-item-value" id="ValueUnit" value="" placeholder="empty for default units" onchange="updateData()" pattern="[A-Z0-9: ]*">
+        </div>
+        <div class="sdpi-item" type="field">
             <div class="sdpi-item-label">Value Precision</div>
             <input class="sdpi-item-value" id="ValuePrecision" value="" placeholder="2" onchange="updateData()" pattern="[0-9]">
         </div>
@@ -109,6 +113,7 @@
             if (settings['ChartThicknessValue']) { ChartThicknessValue.value = settings['ChartThicknessValue'] };
             if (settings['ChartChevronSizeValue']) { ChartChevronSizeValue.value = settings['ChartChevronSizeValue'] };
             if (settings['AbsValText']) { AbsValText.value = settings['AbsValText'] };
+            if (settings['ValueUnit']) { ValueUnit.value = settings['ValueUnit'] };
             if (settings['ValuePrecision']) { ValuePrecision.value = settings['ValuePrecision'] };
             if (settings['HideLabelOutsideMinMaxTop']) { HideLabelOutsideMinMaxTop.checked = settings['HideLabelOutsideMinMaxTop'] };
             if (settings['HideLabelOutsideMinMaxBottom']) { HideLabelOutsideMinMaxBottom.checked = settings['HideLabelOutsideMinMaxBottom'] };
@@ -131,6 +136,7 @@
                 "ChartThicknessValue": ChartThicknessValue.value,
                 "ChartChevronSizeValue": ChartChevronSizeValue.value,
                 "AbsValText": AbsValText.value,
+                "ValueUnit": ValueUnit.value,
                 "ValuePrecision": ValuePrecision.value,
                 "HideLabelOutsideMinMaxTop": HideLabelOutsideMinMaxTop.checked,
                 "HideLabelOutsideMinMaxBottom": HideLabelOutsideMinMaxBottom.checked

--- a/FlightStreamDeck.AddOn/PropertyInspector/GenericToggle.html
+++ b/FlightStreamDeck.AddOn/PropertyInspector/GenericToggle.html
@@ -27,6 +27,14 @@
             <div class="sdpi-item-label">Display value</div>
             <input class="sdpi-item-value" id="DisplayValue" value="" placeholder="Empty for toggle button" pattern="[A-Z0-9: ]*">
         </div>
+        <div class="sdpi-item" type="field">
+            <div class="sdpi-item-label">Display Value Units</div>
+            <input class="sdpi-item-value" id="DisplayValueUnit" value="" placeholder="empty for default units" pattern="[A-Z0-9: ]*">
+        </div>
+        <div class="sdpi-item" type="field">
+            <div class="sdpi-item-label">Display Value Precision</div>
+            <input class="sdpi-item-value" id="DisplayValuePrecision" value="" placeholder="Empty for default precision" pattern="[A-Z0-9: ]*">
+        </div>
         <div type="group" class="sdpi-item" id="messagegroup">
             <div class="sdpi-item-label">Custom ON/OFF images</div>
             <div class="sdpi-item-group">
@@ -59,6 +67,8 @@
             if (settings['ToggleValueData']) { ToggleValueData.value = settings['ToggleValueData'] };
             if (settings['FeedbackValue']) { FeedbackValue.value = settings['FeedbackValue'] };
             if (settings['DisplayValue']) { DisplayValue.value = settings['DisplayValue'] };
+            if (settings['DisplayValueUnit']) { DisplayValueUnit.value = settings['DisplayValueUnit'] };
+            if (settings['DisplayValuePrecision']) { DisplayValuePrecision.value = settings['DisplayValuePrecision'] };
             if (settings['ImageOn']) {
                 setFileLabel(on_image_file_selector, settings['ImageOn']);
             };

--- a/FlightStreamDeck.Core/Structs.cs
+++ b/FlightStreamDeck.Core/Structs.cs
@@ -1608,4 +1608,16 @@
             return input.ToString().Replace("MOBIFLIGHT_", "MobiFlight.");
         }
     }
+
+    public struct ValueEntry
+    {
+        public ValueEntry(string unit, short decimals)
+        {
+            Unit = unit;
+            Decimals = decimals;
+        }
+
+        public string Unit;
+        public short Decimals;
+    }
 }

--- a/FlightStreamDeck.Logics/Actions/GenericGaugeAction.cs
+++ b/FlightStreamDeck.Logics/Actions/GenericGaugeAction.cs
@@ -20,6 +20,7 @@ namespace FlightStreamDeck.Logics.Actions
         public string DisplayValue { get; set; }
         public string SubDisplayValue { get; set; }
         public string Type { get; set; }
+        public string ValueUnit { get; set; }
         public string ValuePrecision { get; set; }
         public string HeaderBottom { get; set; }
         public string DisplayValueBottom { get; set; }
@@ -42,6 +43,7 @@ namespace FlightStreamDeck.Logics.Actions
                 string.IsNullOrEmpty(DisplayValueBottom) &&
                 string.IsNullOrEmpty(ChartSplitValue) &&
                 string.IsNullOrEmpty(AbsValText) &&
+                string.IsNullOrEmpty(ValueUnit) &&
                 string.IsNullOrEmpty(ValuePrecision) &&
                 !HideLabelOutsideMinMaxTop &&
                 !HideLabelOutsideMinMaxBottom &&
@@ -67,6 +69,7 @@ namespace FlightStreamDeck.Logics.Actions
         private TOGGLE_VALUE? displayValueBottom = null;
         private TOGGLE_VALUE? minValue = null;
         private TOGGLE_VALUE? maxValue = null;
+        private ValueEntry displayValueEntry = new ValueEntry();
 
         private float currentValue = 0;
         private float currentValueBottom = 0;
@@ -86,6 +89,7 @@ namespace FlightStreamDeck.Logics.Actions
             MinValue = "0",
             MaxValue = "30",
             AbsValText = "false",
+            ValueUnit = string.Empty,
             ValuePrecision = "2",
             HideLabelOutsideMinMaxTop = false,
             HideLabelOutsideMinMaxBottom = false
@@ -160,13 +164,21 @@ namespace FlightStreamDeck.Logics.Actions
             TOGGLE_VALUE? newMinValue = enumConverter.GetVariableEnum(this.settings.MinValue);
             TOGGLE_VALUE? newMaxValue = enumConverter.GetVariableEnum(this.settings.MaxValue);
 
-            if (newDisplayValue != displayValue || newDisplayValueBottom != displayValueBottom || newSubDisplayValue != subDisplayValue || newMinValue != minValue || newMaxValue != maxValue)
+            short.TryParse(settings.ValuePrecision, out short result);
+            ValueEntry newDisplayValueEntry = new ValueEntry()
+            {
+                Unit = settings.ValueUnit,
+                Decimals = result
+            };
+
+            if (newDisplayValue != displayValue || newDisplayValueBottom != displayValueBottom || newSubDisplayValue != subDisplayValue || newMinValue != minValue || newMaxValue != maxValue || Newtonsoft.Json.JsonConvert.SerializeObject(newDisplayValueEntry) != Newtonsoft.Json.JsonConvert.SerializeObject(displayValueEntry))
             {
                 DeRegisterValues();
             }
 
             toggleEvent = newToggleEvent;
             displayValue = newDisplayValue;
+            displayValueEntry = newDisplayValueEntry;
             subDisplayValue = newSubDisplayValue;
             displayValueBottom = newDisplayValueBottom;
             minValue = newMinValue;
@@ -226,8 +238,8 @@ namespace FlightStreamDeck.Logics.Actions
         private void RegisterValues()
         {
             if (toggleEvent.HasValue) flightConnector.RegisterToggleEvent(toggleEvent.Value);
-            if (displayValue.HasValue) flightConnector.RegisterSimValue(displayValue.Value);
-            if (subDisplayValue.HasValue) flightConnector.RegisterSimValue(subDisplayValue.Value);
+            if (displayValue.HasValue) flightConnector.RegisterSimValue(displayValue.Value, displayValueEntry);
+            if (subDisplayValue.HasValue) flightConnector.RegisterSimValue(subDisplayValue.Value, displayValueEntry);
             if (displayValueBottom.HasValue) flightConnector.RegisterSimValue(displayValueBottom.Value);
             if (minValue.HasValue) flightConnector.RegisterSimValue(minValue.Value);
             if (maxValue.HasValue) flightConnector.RegisterSimValue(maxValue.Value);
@@ -235,8 +247,8 @@ namespace FlightStreamDeck.Logics.Actions
 
         private void DeRegisterValues()
         {
-            if (displayValue.HasValue) flightConnector.DeRegisterSimValue(displayValue.Value);
-            if (subDisplayValue.HasValue) flightConnector.DeRegisterSimValue(subDisplayValue.Value);
+            if (displayValue.HasValue) flightConnector.DeRegisterSimValue(displayValue.Value, displayValueEntry);
+            if (subDisplayValue.HasValue) flightConnector.DeRegisterSimValue(subDisplayValue.Value, displayValueEntry);
             if (displayValueBottom.HasValue) flightConnector.DeRegisterSimValue(displayValueBottom.Value);
             if (minValue.HasValue) flightConnector.DeRegisterSimValue(minValue.Value);
             if (maxValue.HasValue) flightConnector.DeRegisterSimValue(maxValue.Value);

--- a/FlightStreamDeck.Logics/IFlightConnector.cs
+++ b/FlightStreamDeck.Logics/IFlightConnector.cs
@@ -43,8 +43,10 @@ namespace FlightStreamDeck.Logics
         void RegisterToggleEvent(TOGGLE_EVENT toggleAction);
 
         void RegisterSimValue(TOGGLE_VALUE simValue);
+        void RegisterSimValue(TOGGLE_VALUE simValue, ValueEntry simValueEntry);
         void DeRegisterSimValue(TOGGLE_VALUE simValue);
-        
+        void DeRegisterSimValue(TOGGLE_VALUE simValue, ValueEntry simValueEntry);
+
         void RegisterSimValues(params TOGGLE_VALUE[] simValues);
         void DeRegisterSimValues(params TOGGLE_VALUE[] simValues);
     }

--- a/FlightStreamDeck.SimConnectFSX/EventValueLibrary.cs
+++ b/FlightStreamDeck.SimConnectFSX/EventValueLibrary.cs
@@ -5,12 +5,12 @@ using System.Collections.Generic;
 
 namespace FlightStreamDeck.SimConnectFSX
 {
-    class EventValueLibrary
+    static class EventValueLibrary
     {
-        private const string DEFAULT_UNIT = "number";
-        private const int DEFAULT_DECIMALS = 0;
+        internal const string DEFAULT_UNIT = "number";
+        internal const int DEFAULT_DECIMALS = 0;
 
-        private static Dictionary<TOGGLE_VALUE, ValueEntry> availableValues = new Dictionary<TOGGLE_VALUE, ValueEntry>()
+        internal static Dictionary<TOGGLE_VALUE, ValueEntry> availableValues = new Dictionary<TOGGLE_VALUE, ValueEntry>()
         {
             { TOGGLE_VALUE.THROTTLE_LOWER_LIMIT, new ValueEntry("Percent", 2) },
             { TOGGLE_VALUE.GENERAL_ENG_RPM__1, new ValueEntry("Rpm", 1) },
@@ -331,24 +331,48 @@ namespace FlightStreamDeck.SimConnectFSX
             { TOGGLE_VALUE.TURB_ENG_PRIMARY_NOZZLE_PERCENT__1, new ValueEntry("Percent", 0) },
             { TOGGLE_VALUE.TURB_ENG_PRIMARY_NOZZLE_PERCENT__2, new ValueEntry("Percent", 0) },
         };
+    }
 
-        public EventValueLibrary()
+    public static class EventValueLibraryExtensions { 
+        public static bool isSpecial(this Dictionary<TOGGLE_VALUE, ValueEntry> input, TOGGLE_VALUE value)
         {
+            return input.ContainsKey(value);
         }
 
-        public bool isSpecial(TOGGLE_VALUE value)
+        public static string GetUnit(this TOGGLE_VALUE value, Dictionary<TOGGLE_VALUE, ValueEntry> specifiedValuesWithUnitAndDecimals)
         {
-            return availableValues.ContainsKey(value);
+            string output = EventValueLibrary.DEFAULT_UNIT;
+
+            if (specifiedValuesWithUnitAndDecimals.isSpecial(value))
+            {
+                output = specifiedValuesWithUnitAndDecimals[value].Unit;
+            }
+            else if (EventValueLibrary.availableValues.isSpecial(value))
+            {
+                output = EventValueLibrary.availableValues[value].Unit;
+            }
+
+            output = output == null ? EventValueLibrary.DEFAULT_UNIT : output;
+
+            return output;
         }
 
-        public string GetUnit(TOGGLE_VALUE value)
+        public static int GetDecimals(this TOGGLE_VALUE value, Dictionary<TOGGLE_VALUE, ValueEntry> specifiedValuesWithUnitAndDecimals)
         {
-            return isSpecial(value) ? availableValues[value].Unit : DEFAULT_UNIT;
-        }
+            int output = EventValueLibrary.DEFAULT_DECIMALS;
 
-        public int GetDecimals(TOGGLE_VALUE value)
-        {
-            return isSpecial(value) ? availableValues[value].Decimals : DEFAULT_DECIMALS;
+            if (specifiedValuesWithUnitAndDecimals.isSpecial(value))
+            {
+                output = specifiedValuesWithUnitAndDecimals[value].Decimals;
+            }
+            else if (EventValueLibrary.availableValues.isSpecial(value))
+            {
+                output = EventValueLibrary.availableValues[value].Decimals;
+            }
+
+            output = output == int.MinValue ? EventValueLibrary.DEFAULT_DECIMALS : output;
+
+            return output;
         }
     }
 }

--- a/FlightStreamDeck.SimConnectFSX/SimConnectFlightConnector.cs
+++ b/FlightStreamDeck.SimConnectFSX/SimConnectFlightConnector.cs
@@ -22,8 +22,7 @@ namespace FlightStreamDeck.SimConnectFSX
 
         private readonly List<TOGGLE_EVENT> genericEvents = new List<TOGGLE_EVENT>();
         private readonly HashSet<TOGGLE_VALUE> genericValues = new HashSet<TOGGLE_VALUE>();
-
-        private readonly EventValueLibrary eventLib = new EventValueLibrary();
+        private readonly Dictionary<TOGGLE_VALUE, ValueEntry> specifiedValuesWithUnitAndDecimals = new Dictionary<TOGGLE_VALUE, ValueEntry>();
 
         private readonly object lockLists = new object();
 
@@ -595,8 +594,8 @@ namespace FlightStreamDeck.SimConnectFSX
 
                             for (int i = 0; i < data.dwDefineCount; i++)
                             {
-                                var genericValue = genericValues.ElementAt(i);
-                                int decimals = eventLib.GetDecimals(genericValue);
+                                TOGGLE_VALUE genericValue = genericValues.ElementAt(i);
+                                int decimals = genericValue.GetDecimals(specifiedValuesWithUnitAndDecimals);
                                 double toggleValue = Math.Round(dataArray.Value.Get(i), decimals);
                                 result.Add(genericValue, toggleValue.ToString("F" + decimals.ToString()));
                             }
@@ -715,6 +714,21 @@ namespace FlightStreamDeck.SimConnectFSX
             }
         }
 
+        public void RegisterSimValue(TOGGLE_VALUE simValue, ValueEntry simValueEntry)
+        {
+            var changed = false;
+            lock (lockLists)
+            {
+                logger.LogInformation("Registering {key} {value}", simValue, simValueEntry);
+                changed = genericValues.Add(simValue);
+                specifiedValuesWithUnitAndDecimals.Add(simValue, simValueEntry);
+            }
+            if (changed)
+            {
+                RegisterGenericValues();
+            }
+        }
+
         public void DeRegisterSimValue(TOGGLE_VALUE simValue)
         {
             var changed = false;
@@ -722,6 +736,21 @@ namespace FlightStreamDeck.SimConnectFSX
             {
                 logger.LogInformation("De-Registering {value}", simValue);
                 changed = genericValues.Remove(simValue);
+            }
+            if (changed)
+            {
+                RegisterGenericValues();
+            }
+        }
+
+        public void DeRegisterSimValue(TOGGLE_VALUE simValue, ValueEntry simValueEntry)
+        {
+            var changed = false;
+            lock (lockLists)
+            {
+                logger.LogInformation("De-Registering {value} {sve}", simValue, simValueEntry);
+                changed = genericValues.Remove(simValue);
+                specifiedValuesWithUnitAndDecimals.Remove(simValue);
             }
             if (changed)
             {
@@ -813,7 +842,7 @@ namespace FlightStreamDeck.SimConnectFSX
                             simconnect.AddToDataDefinition(
                                 DEFINITIONS.GenericData,
                                 value,
-                                eventLib.GetUnit(simValue),
+                                simValue.GetUnit(specifiedValuesWithUnitAndDecimals),
                                 SIMCONNECT_DATATYPE.FLOAT64,
                                 0.0f,
                                 SimConnect.SIMCONNECT_UNUSED

--- a/FlightStreamDeck.SimConnectFSX/Structs.cs
+++ b/FlightStreamDeck.SimConnectFSX/Structs.cs
@@ -123,16 +123,4 @@ namespace FlightStreamDeck.SimConnectFSX
             return Data[index];
         }
     }
-
-    struct ValueEntry
-    {
-        public ValueEntry(string unit, short decimals)
-        {
-            Unit = unit;
-            Decimals = decimals;
-        }
-
-        public string Unit;
-        public short Decimals;
-    }
 }


### PR DESCRIPTION
There are some quirks here.

- I only apply this to the generic gauges "display value" and "sub display value".
  - I omitted applying it or adding another set of unit/precisions for the "bottom value" when in custom mode.
- if you have a display value on more than one button on a profile, the last one updated takes precedence for unit/precision.
  - we only keep track of the registered TOGGLE_VALUE, so we have nothing more unique to tie what precision/unit you want for a specific button... We can probably discuss this if you feel that might cause too much confusion.  Odds that someone uses the same variable and want a diff precision/unit on the same profile?

Hit me up on discord @nguyenquyhy  if you want to chat about it 👍 

this will close #26 