### PR TITLE
nav/com/xpdr buttons would sometimes show error yellow trinangles whe…

### DIFF
--- a/FlightStreamDeck.SimConnectFSX/SimConnectFlightConnector.cs
+++ b/FlightStreamDeck.SimConnectFSX/SimConnectFlightConnector.cs
@@ -851,6 +851,9 @@ namespace FlightStreamDeck.SimConnectFSX
 
         public void Trigger(TOGGLE_EVENT toggleAction, uint data = 0)
         {
+            ///attempt to add it to the generics, if it isnt there already
+            ///was getting some weird edge cases when coming back from the numpad profiles on nav/com/xpdr actions
+            RegisterToggleEvent(toggleAction);
             logger.LogInformation("Toggle {action} {data}", toggleAction, data);
             SendGenericCommand(toggleAction, data);
         }


### PR DESCRIPTION
…n coming back from the numpad profile.  The only thing I could see was maybe the generics list was getting wiped out for our toggle event. Adding an attempt to register it if it isn't in our list already.