### PR TITLE
Updated to TrySetResult. This hasn't changed recently, and the errors…

### DIFF
--- a/FlightStreamDeck.Logics/Actions/NavComAction.cs
+++ b/FlightStreamDeck.Logics/Actions/NavComAction.cs
@@ -92,7 +92,7 @@ namespace FlightStreamDeck.Logics.Actions
             if (initializationTcs != null)
             {
                 logger.LogDebug("Trigger Task completion for initialization");
-                initializationTcs.SetResult(true);
+                initializationTcs.TrySetResult(true);
             }
         }
 

--- a/FlightStreamDeck.Logics/Actions/NumberFunctionAction.cs
+++ b/FlightStreamDeck.Logics/Actions/NumberFunctionAction.cs
@@ -44,14 +44,14 @@ namespace FlightStreamDeck.Logics.Actions
                     case "tech.flighttracker.streamdeck.number.enter":
                         if (DeckLogic.NumpadTcs != null)
                         {
-                            DeckLogic.NumpadTcs.SetResult((DeckLogic.NumpadParams.Value, false));
+                            DeckLogic.NumpadTcs.TrySetResult((DeckLogic.NumpadParams.Value, false));
                         }
                         await StreamDeck.SwitchToProfileAsync(param.PluginUUID, args.Device, null);
                         break;
                     case "tech.flighttracker.streamdeck.number.cancel":
                         if (DeckLogic.NumpadTcs != null)
                         {
-                            DeckLogic.NumpadTcs.SetResult((null, false));
+                            DeckLogic.NumpadTcs.TrySetResult((null, false));
                         }
                         await StreamDeck.SwitchToProfileAsync(param.PluginUUID, args.Device, null);
                         break;
@@ -61,14 +61,14 @@ namespace FlightStreamDeck.Logics.Actions
                             DeckLogic.NumpadParams.Value = "1200";
                             if (DeckLogic.NumpadTcs != null)
                             {
-                                DeckLogic.NumpadTcs.SetResult((DeckLogic.NumpadParams.Value, false));
+                                DeckLogic.NumpadTcs.TrySetResult((DeckLogic.NumpadParams.Value, false));
                             }
                         }
                         else
                         {
                             if (DeckLogic.NumpadTcs != null)
                             {
-                                DeckLogic.NumpadTcs.SetResult((DeckLogic.NumpadParams.Value, true));
+                                DeckLogic.NumpadTcs.TrySetResult((DeckLogic.NumpadParams.Value, true));
                             }
                         }
                         await StreamDeck.SwitchToProfileAsync(param.PluginUUID, args.Device, null);


### PR DESCRIPTION
… I get were pointing to task issues (when I was seeing them).

Increasing the wait before firing the toggle trigger seemed to help too, but we'll give this a shot first because I don't want to introduced unnecessary delay on the freq/xpdr toggle actions.

These were the errors I was seeing in the streamdeck logs (%appdata%\Elgato\StreamDeck\logs), when hitting the xfer option on the numpad:
06:35:40.789 An attempt was made to transition a task to a final state when it had already completed.
06:37:21.562 An attempt was made to transition a task to a final state when it had already completed.
06:39:44.699 An attempt was made to transition a task to a final state when it had already completed.

closes #132 