### PR TITLE
Syncronise data requests and data definition registrations

### DIFF
--- a/FlightStreamDeck.SimConnectFSX/SimConnectFlightConnector.cs
+++ b/FlightStreamDeck.SimConnectFSX/SimConnectFlightConnector.cs
@@ -683,12 +683,20 @@ namespace FlightStreamDeck.SimConnectFSX
                     while (true)
                     {
                         await Task.Delay(StatusDelayMilliseconds);
-                        cts?.Token.ThrowIfCancellationRequested();
-                        simconnect?.RequestDataOnSimObjectType(DATA_REQUESTS.FLIGHT_STATUS, DEFINITIONS.FlightStatus, 0, SIMCONNECT_SIMOBJECT_TYPE.USER);
-
-                        if (genericValues.Count > 0 && isGenericValueRegistered)
+                        await smGeneric.WaitAsync();
+                        try
                         {
-                            simconnect?.RequestDataOnSimObjectType(DATA_REQUESTS.TOGGLE_VALUE_DATA, DEFINITIONS.GenericData, 0, SIMCONNECT_SIMOBJECT_TYPE.USER);
+                            cts?.Token.ThrowIfCancellationRequested();
+                            simconnect?.RequestDataOnSimObjectType(DATA_REQUESTS.FLIGHT_STATUS, DEFINITIONS.FlightStatus, 0, SIMCONNECT_SIMOBJECT_TYPE.USER);
+
+                            if (genericValues.Count > 0 && isGenericValueRegistered)
+                            {
+                                simconnect?.RequestDataOnSimObjectType(DATA_REQUESTS.TOGGLE_VALUE_DATA, DEFINITIONS.GenericData, 0, SIMCONNECT_SIMOBJECT_TYPE.USER);
+                            }
+                        }
+                        finally
+                        {
+                            smGeneric.Release();
                         }
                     }
                 }
@@ -830,9 +838,9 @@ namespace FlightStreamDeck.SimConnectFSX
 
             Task.Run(async () =>
             {
+                await smGeneric.WaitAsync();
                 try
                 {
-                    await smGeneric.WaitAsync();
 
                     await Task.Delay(500, cts.Token);
                     cts.Token.ThrowIfCancellationRequested();


### PR DESCRIPTION
I was experiencing many simulator disconnects and reconnection loops. I'm not entirely sure what the cause is but I suspect that it may be due to data definitions being changed while a data request call is being processed.

Wrapping data requests with the 'smGeneric' semaphore prevents this and the exceptions have all but disappeared.


```
2021-01-23 14:56:36.403 -05:00 [INF] Run action is triggered.
2021-01-23 14:56:36.403 -05:00 [INF] Run action is executing...
2021-01-23 14:56:36.505 -05:00 [INF] Connected to Flight Simulator
2021-01-23 14:56:36.913 -05:00 [INF] Registering generic data structure:
- PLANE_BANK_DEGREES PLANE BANK DEGREES
- PLANE_PITCH_DEGREES PLANE PITCH DEGREES
- GENERAL_ENG_MIXTURE_LEVER_POSITION__1 GENERAL ENG MIXTURE LEVER POSITION:1
- GEAR_TOTAL_PCT_EXTENDED GEAR TOTAL PCT EXTENDED
- INDICATED_ALTITUDE INDICATED ALTITUDE
- VERTICAL_SPEED VERTICAL SPEED
- GENERAL_ENG_PROPELLER_LEVER_POSITION__1 GENERAL ENG PROPELLER LEVER POSITION:1
- AIRSPEED_INDICATED AIRSPEED INDICATED
2021-01-23 14:56:37.055 -05:00 [ERR] Exception received
System.Runtime.InteropServices.COMException (0xC00000B0): 0xC00000B0
   at System.Runtime.InteropServices.Marshal.ThrowExceptionForHR(Int32 errorCode)
   at Microsoft.FlightSimulator.SimConnect.SimConnect.ReceiveDispatch(SignalProcDelegate pfcnSignal)
   at FlightStreamDeck.SimConnectFSX.SimConnectFlightConnector.HandleSimConnectEvents(IntPtr hWnd, Int32 message, IntPtr wParam, IntPtr lParam, Boolean& isHandled) in D:\Hy\Codes\_nguyenquyhy\FlightStreamDeck\FlightStreamDeck.SimConnectFSX\SimConnectFlightConnector.cs:line 75
2021-01-23 14:56:37.163 -05:00 [INF] Run action is triggered.
2021-01-23 14:56:38.420 -05:00 [INF] Run action is executing...
2021-01-23 14:56:38.470 -05:00 [INF] Connected to Flight Simulator
2021-01-23 14:56:38.934 -05:00 [INF] Registering generic data structure:
- PLANE_BANK_DEGREES PLANE BANK DEGREES
- PLANE_PITCH_DEGREES PLANE PITCH DEGREES
- GENERAL_ENG_MIXTURE_LEVER_POSITION__1 GENERAL ENG MIXTURE LEVER POSITION:1
- GEAR_TOTAL_PCT_EXTENDED GEAR TOTAL PCT EXTENDED
- INDICATED_ALTITUDE INDICATED ALTITUDE
- VERTICAL_SPEED VERTICAL SPEED
- GENERAL_ENG_PROPELLER_LEVER_POSITION__1 GENERAL ENG PROPELLER LEVER POSITION:1
- AIRSPEED_INDICATED AIRSPEED INDICATED
2021-01-23 14:56:39.459 -05:00 [ERR] Exception received
System.Runtime.InteropServices.COMException (0xC00000B0): 0xC00000B0
   at System.Runtime.InteropServices.Marshal.ThrowExceptionForHR(Int32 errorCode)
   at Microsoft.FlightSimulator.SimConnect.SimConnect.ReceiveDispatch(SignalProcDelegate pfcnSignal)
   at FlightStreamDeck.SimConnectFSX.SimConnectFlightConnector.HandleSimConnectEvents(IntPtr hWnd, Int32 message, IntPtr wParam, IntPtr lParam, Boolean& isHandled) in D:\Hy\Codes\_nguyenquyhy\FlightStreamDeck\FlightStreamDeck.SimConnectFSX\SimConnectFlightConnector.cs:line 75

```