### PR TITLE
Fixing: Generic Toggle Header unsaveable

### DIFF
--- a/FlightStreamDeck.AddOn/PropertyInspector/GenericToggle.html
+++ b/FlightStreamDeck.AddOn/PropertyInspector/GenericToggle.html
@@ -9,7 +9,7 @@
     <div class="sdpi-wrapper">
         <div class="sdpi-item" type="field">
             <div class="sdpi-item-label">Header</div>
-            <input class="sdpi-item-value" id="e.g. Header" value="" placeholder="YD">
+            <input class="sdpi-item-value" id="Header" value="" placeholder="e.g. YD">
         </div>
         <div class="sdpi-item" type="field">
             <div class="sdpi-item-label">Toggle event</div>


### PR DESCRIPTION
Due to mixing up placeholder and id on that HTML Property it was not possible to set Header Values in Generic Toggles.