### PR TITLE
Change header element to textarea

### DIFF
--- a/FlightStreamDeck.AddOn/PropertyInspector/GenericToggle.html
+++ b/FlightStreamDeck.AddOn/PropertyInspector/GenericToggle.html
@@ -7,9 +7,11 @@
 </head>
 <body>
     <div class="sdpi-wrapper">
-        <div class="sdpi-item" type="field">
+        <div class="sdpi-item" type="textarea">
             <div class="sdpi-item-label">Header</div>
-            <input class="sdpi-item-value" id="Header" value="" placeholder="e.g. YD">
+            <span class="sdpi-item-value textarea">
+                <textarea type="textarea" id="Header" placeholder="Write header here, can include multiple lines. Adjust with spaces"></textarea>
+            </span>
         </div>
         <div class="sdpi-item" type="field">
             <div class="sdpi-item-label">Toggle event</div>


### PR DESCRIPTION
Change header to textarea, this allows for newlines in header which helps with long names.

Needs improvement: Text does not auto-center and needs to be adjusted with spaces.